### PR TITLE
Query string fixes

### DIFF
--- a/script/acceptance_tests/server.cr
+++ b/script/acceptance_tests/server.cr
@@ -20,7 +20,7 @@ post "/submit" do |env|
 end
 
 # catch-all routes for all other requests and methods
-# ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"] 
+# ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"]
 get "/catch-all" do |env|
   "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
 end
@@ -44,6 +44,5 @@ end
 options "/catch-all" do |env|
   "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
 end
-
 
 Kemal.run

--- a/script/acceptance_tests/server.cr
+++ b/script/acceptance_tests/server.cr
@@ -15,4 +15,35 @@ get "/crest-client" do |env|
   "Hi, %s! You sent a request that was successfully verified with HMAC auth for the crest-client" % env.kemal_authorized_client?
 end
 
+post "/submit" do |env|
+  "Hi, %s! I got your POST request" % env.kemal_authorized_client?
+end
+
+# catch-all routes for all other requests and methods
+# ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"] 
+get "/catch-all" do |env|
+  "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
+end
+
+post "/catch-all" do |env|
+  "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
+end
+
+put "/catch-all" do |env|
+  "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
+end
+
+patch "/catch-all" do |env|
+  "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
+end
+
+delete "/catch-all" do |env|
+  "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
+end
+
+options "/catch-all" do |env|
+  "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
+end
+
+
 Kemal.run

--- a/script/acceptance_tests/server.cr
+++ b/script/acceptance_tests/server.cr
@@ -20,7 +20,7 @@ post "/submit" do |env|
 end
 
 # catch-all routes for all other requests and methods
-# ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"]
+# ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 get "/catch-all" do |env|
   "Hi, %s! Welcome to catch-all" % env.kemal_authorized_client?
 end

--- a/script/acceptance_tests/tests.cr
+++ b/script/acceptance_tests/tests.cr
@@ -3,6 +3,32 @@ require "crest"
 require "http/client"
 require "spec"
 
+describe "All HTTP Methods" do
+  ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"].each do |method|
+    it "successfully validates a #{method} request" do
+      client = Kemal::Hmac::Client.new("my_standard_client", "my_secret_2")
+
+      path = "/catch-all"
+
+      headers = HTTP::Headers.new
+      client.generate_headers(path).each do |key, value|
+        headers.add(key, value)
+      end
+
+      response = HTTP::Client.get("http://localhost:3000#{path}", headers: headers)
+
+      request = HTTP::Request.new(
+        method,
+        "/api",
+        headers: headers,
+      )
+
+      response.status_code.should eq 200
+      response.body.should contain "Hi, my_standard_client!"
+    end
+  end
+end
+
 describe "crest" do
   it "successfully sends a request with HMAC auth with the crest client to the crest-client endpoint" do
     client = Kemal::Hmac::Client.new("my_crest_client", "my_secret")
@@ -47,6 +73,36 @@ describe "crest" do
       ex.response.body.should contain "Unauthorized: HMAC token does not match"
     end
   end
+
+  it "fails to send a request with HMAC auth to an endpoint using the POST HTTP verb" do
+    client = Kemal::Hmac::Client.new("my_crest_client", "incorrect_secret")
+
+    path = "/submit"
+
+    begin
+      Crest.post(
+        "http://localhost:3000#{path}",
+        headers: client.generate_headers(path)
+      )
+    rescue ex : Crest::Unauthorized
+      ex.response.status_code.should eq 401
+      ex.response.body.should contain "Unauthorized: HMAC token does not match"
+    end
+  end
+
+  it "successfully sends a request with HMAC auth with the crest client an endpoint using the POST HTTP verb" do
+    client = Kemal::Hmac::Client.new("my_crest_client", "my_secret")
+
+    path = "/submit"
+
+    response = Crest.post(
+      "http://localhost:3000#{path}",
+      headers: client.generate_headers(path)
+    )
+
+    response.status_code.should eq 200
+    response.body.should contain "Hi, my_crest_client! I got your POST request"
+  end
 end
 
 describe "http/client" do
@@ -64,6 +120,22 @@ describe "http/client" do
 
     response.status_code.should eq 200
     response.body.should contain "Hi, my_standard_client!"
+  end
+
+  it "successfully sends a request with HMAC auth with the http-client to an endpoint using the POST HTTP verb" do
+    client = Kemal::Hmac::Client.new("my_standard_client", "my_secret_2")
+
+    path = "/submit"
+
+    headers = HTTP::Headers.new
+    client.generate_headers(path).each do |key, value|
+      headers.add(key, value)
+    end
+
+    response = HTTP::Client.post("http://localhost:3000#{path}", headers: headers)
+
+    response.status_code.should eq 200
+    response.body.should contain "Hi, my_standard_client! I got your POST request"
   end
 
   it "successfully sends a request with HMAC auth with the http-client to the http-client endpoint with query string params" do

--- a/script/acceptance_tests/tests.cr
+++ b/script/acceptance_tests/tests.cr
@@ -18,10 +18,24 @@ describe "crest" do
     response.body.should contain "Hi, my_crest_client!"
   end
 
+  it "successfully sends a request with HMAC auth with the crest client to the crest-client endpoint with query string params" do
+    client = Kemal::Hmac::Client.new("my_crest_client", "my_secret")
+
+    path = "/crest-client"
+
+    response = Crest.get(
+      "http://localhost:3000#{path}",
+      headers: client.generate_headers(path)
+    )
+
+    response.status_code.should eq 200
+    response.body.should contain "Hi, my_crest_client!"
+  end
+
   it "fails to send a request with HMAC auth with the crest client to the crest-client endpoint" do
     client = Kemal::Hmac::Client.new("my_crest_client", "incorrect_secret")
 
-    path = "/crest-client"
+    path = "/crest-client?foo=bar&q=baz&operation=1/2"
 
     begin
       Crest.get(
@@ -40,6 +54,22 @@ describe "http/client" do
     client = Kemal::Hmac::Client.new("my_standard_client", "my_secret_2")
 
     path = "/http-client"
+
+    headers = HTTP::Headers.new
+    client.generate_headers(path).each do |key, value|
+      headers.add(key, value)
+    end
+
+    response = HTTP::Client.get("http://localhost:3000#{path}", headers: headers)
+
+    response.status_code.should eq 200
+    response.body.should contain "Hi, my_standard_client!"
+  end
+
+  it "successfully sends a request with HMAC auth with the http-client to the http-client endpoint with query string params" do
+    client = Kemal::Hmac::Client.new("my_standard_client", "my_secret_2")
+
+    path = "/http-client?foo=bar&q=baz&operation=1/2"
 
     headers = HTTP::Headers.new
     client.generate_headers(path).each do |key, value|

--- a/src/kemal-hmac/client.cr
+++ b/src/kemal-hmac/client.cr
@@ -22,7 +22,7 @@ module Kemal::Hmac
     # :return: a Hash of the HMAC headers
     def generate_headers(path : String) : Hash(String, String)
       timestamp = Time::Format::ISO_8601_DATE_TIME.format(Time.utc)
-      hmac_token = Kemal::Hmac::Token.new(@client, path, timestamp, @algorithm).hexdigest(@secret)
+      hmac_token = Kemal::Hmac::Token.new(@client, path.split("?").first, timestamp, @algorithm).hexdigest(@secret)
 
       return {
         HMAC_CLIENT_HEADER    => @client,


### PR DESCRIPTION
This pull request introduces new tests for the `Kemal::Hmac` module and makes a small but important change to the `generate_headers` method to ensure correct HMAC token generation. The most important changes include adding tests for request handling with query string parameters and modifying the `generate_headers` method to handle paths with query strings correctly.